### PR TITLE
feat(app): org custom roles, invites, and permission-aware UI

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -25,10 +25,19 @@ function MainContent({ children }: { children: React.ReactNode }) {
   const isSignupPage = pathname?.startsWith("/signup") ?? false;
   const isCustomerOnboardingPage =
     pathname?.startsWith("/customer-onboarding") ?? false;
+  const isInvitePage = pathname?.startsWith("/invite") ?? false;
   const shouldHideSidebar =
-    isHomePage || isLoginPage || isSignupPage || isCustomerOnboardingPage;
+    isHomePage ||
+    isLoginPage ||
+    isSignupPage ||
+    isCustomerOnboardingPage ||
+    isInvitePage;
   const shouldHideHeader =
-    isHomePage || isLoginPage || isSignupPage || isCustomerOnboardingPage;
+    isHomePage ||
+    isLoginPage ||
+    isSignupPage ||
+    isCustomerOnboardingPage ||
+    isInvitePage;
 
   if (shouldHideSidebar) {
     return (

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { useAuth } from "@/contexts/auth-context";
+import { useOrganization } from "@/contexts/organization-context";
+import {
+  authApi,
+  getApiErrorMessage,
+  invitesApi,
+  setActiveOrgId,
+  setAuthToken,
+  type InvitePreview,
+} from "@/lib/api";
+import { buildNavAccess, defaultPostLoginPath } from "@/lib/nav-access";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+function InviteShell({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex min-h-screen flex-col items-center justify-center px-6 py-8 lg:py-0">
+        <a
+          href="/"
+          className="mb-6 flex items-center text-2xl font-semibold text-foreground"
+        >
+          <Image
+            width={250}
+            height={40}
+            src="/wordmark.svg"
+            alt="Wraptron"
+            className="dark:brightness-0 dark:invert"
+          />
+        </a>
+        <div className="w-full rounded-lg border border-border bg-card text-card-foreground shadow-sm sm:max-w-md">
+          <div className="space-y-4 p-6 sm:p-8 md:space-y-6">
+            <h1 className="text-xl font-bold leading-tight tracking-tight md:text-2xl">
+              {title}
+            </h1>
+            {children}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function InviteSummary({ preview }: { preview: InvitePreview }) {
+  const expires = new Date(preview.expires_at);
+  const expiresLabel = Number.isNaN(expires.getTime())
+    ? preview.expires_at
+    : expires.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/40 p-4 text-sm space-y-2">
+      <p>
+        <span className="text-muted-foreground">Organization:</span>{" "}
+        <span className="font-medium">{preview.org_name}</span>
+      </p>
+      <p>
+        <span className="text-muted-foreground">Role:</span>{" "}
+        <span className="font-medium">{preview.role_name}</span>
+      </p>
+      <p>
+        <span className="text-muted-foreground">Email:</span>{" "}
+        <span className="font-medium">{preview.email}</span>
+      </p>
+      <p className="text-muted-foreground text-xs">Expires {expiresLabel}</p>
+    </div>
+  );
+}
+
+function ErrorAlert({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+    >
+      {message}
+    </div>
+  );
+}
+
+function PrimaryButton({
+  children,
+  loading,
+  disabled,
+  type = "button",
+  onClick,
+}: {
+  children: React.ReactNode;
+  loading?: boolean;
+  disabled?: boolean;
+  type?: "button" | "submit";
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type={type}
+      disabled={disabled || loading}
+      onClick={onClick}
+      className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-blue-800"
+    >
+      {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+      {children}
+    </button>
+  );
+}
+
+export default function InvitePage() {
+  const params = useParams<{ token: string }>();
+  const token = params.token;
+  const router = useRouter();
+  const {
+    isAuthenticated,
+    loading: authLoading,
+    refreshUser,
+  } = useAuth();
+  const { refreshOrganizations } = useOrganization();
+
+  const [preview, setPreview] = useState<InvitePreview | null>(null);
+  const [pageLoading, setPageLoading] = useState(true);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [loginPassword, setLoginPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const loadPreview = useCallback(async () => {
+    if (!token) {
+      setPageError("This invite link is invalid.");
+      setPageLoading(false);
+      return;
+    }
+
+    setPageLoading(true);
+    setPageError(null);
+    try {
+      const data = await invitesApi.preview(token);
+      if (data.status !== "pending") {
+        const reason =
+          data.status === "revoked"
+            ? "This invite has been revoked."
+            : data.status === "accepted"
+              ? "This invite has already been accepted."
+              : data.status === "expired"
+                ? "This invite has expired."
+                : "This invite is no longer valid.";
+        setPageError(reason);
+        setPreview(null);
+        return;
+      }
+
+      const expiresAt = new Date(data.expires_at);
+      if (!Number.isNaN(expiresAt.getTime()) && expiresAt.getTime() < Date.now()) {
+        setPageError("This invite has expired.");
+        setPreview(null);
+        return;
+      }
+
+      setPreview(data);
+    } catch (err) {
+      setPageError(
+        getApiErrorMessage(err, "This invite link is invalid or unavailable."),
+      );
+      setPreview(null);
+    } finally {
+      setPageLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void loadPreview();
+  }, [loadPreview]);
+
+  const redirectAfterJoin = async (organizationId: number) => {
+    setActiveOrgId(organizationId);
+    await refreshOrganizations();
+    await refreshUser();
+    router.push(
+      defaultPostLoginPath(
+        buildNavAccess({ globalRole: "user" }),
+      ),
+    );
+  };
+
+  const handleSignup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token || !preview) return;
+    setActionError(null);
+
+    if (!password) {
+      setActionError("Password is required.");
+      return;
+    }
+    if (password.length < 6) {
+      setActionError("Password must be at least 6 characters long.");
+      return;
+    }
+
+    setActionLoading(true);
+    try {
+      const result = await invitesApi.signup(token, {
+        name: name.trim() || undefined,
+        password,
+      });
+      setAuthToken(result.token);
+      await redirectAfterJoin(result.organization_id);
+    } catch (err) {
+      setActionError(
+        getApiErrorMessage(err, "Could not create your account. Please try again."),
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!preview) return;
+    setActionError(null);
+
+    if (!loginPassword) {
+      setActionError("Password is required.");
+      return;
+    }
+
+    setActionLoading(true);
+    try {
+      const result = await authApi.login({
+        email: preview.email,
+        password: loginPassword,
+      });
+      setAuthToken(result.token);
+      await refreshUser();
+      setLoginPassword("");
+    } catch (err) {
+      setActionError(
+        getApiErrorMessage(err, "Invalid email or password. Please try again."),
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleAccept = async () => {
+    if (!token) return;
+    setActionError(null);
+    setActionLoading(true);
+    try {
+      const result = await invitesApi.accept(token);
+      await redirectAfterJoin(result.organization_id);
+    } catch (err) {
+      setActionError(
+        getApiErrorMessage(err, "Could not accept this invite. Please try again."),
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  if (pageLoading || authLoading) {
+    return (
+      <InviteShell title="Organization invite">
+        <div className="flex justify-center py-6">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      </InviteShell>
+    );
+  }
+
+  if (pageError) {
+    return (
+      <InviteShell title="Invite unavailable">
+        <ErrorAlert message={pageError} />
+        <p className="text-sm text-muted-foreground">
+          Ask your organization owner to send a new invite if you still need access.
+        </p>
+      </InviteShell>
+    );
+  }
+
+  if (!preview) {
+    return null;
+  }
+
+  if (preview.flow_type === "signup") {
+    return (
+      <InviteShell title="Join your organization">
+        <InviteSummary preview={preview} />
+        {actionError && <ErrorAlert message={actionError} />}
+        <form className="space-y-4 md:space-y-6" onSubmit={handleSignup}>
+          <div className="space-y-2">
+            <Label htmlFor="name">Your name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Jane Doe"
+              autoComplete="name"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={preview.email}
+              readOnly
+              disabled
+              className="bg-muted"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                className="pr-10"
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus:outline-none"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-5 w-5" />
+                ) : (
+                  <Eye className="h-5 w-5" />
+                )}
+              </button>
+            </div>
+          </div>
+          <PrimaryButton type="submit" loading={actionLoading}>
+            Create account and join
+          </PrimaryButton>
+        </form>
+      </InviteShell>
+    );
+  }
+
+  return (
+    <InviteShell title="Accept organization invite">
+      <InviteSummary preview={preview} />
+      {actionError && <ErrorAlert message={actionError} />}
+      {isAuthenticated ? (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            You&apos;re signed in. Accept this invite to join{" "}
+            <span className="font-medium text-foreground">{preview.org_name}</span>{" "}
+            as <span className="font-medium text-foreground">{preview.role_name}</span>.
+          </p>
+          <PrimaryButton loading={actionLoading} onClick={() => void handleAccept()}>
+            Accept invite
+          </PrimaryButton>
+        </div>
+      ) : (
+        <form className="space-y-4 md:space-y-6" onSubmit={handleLogin}>
+          <p className="text-sm text-muted-foreground">
+            Sign in with your existing account to accept this invite.
+          </p>
+          <div className="space-y-2">
+            <Label htmlFor="login-email">Your email</Label>
+            <Input
+              id="login-email"
+              type="email"
+              value={preview.email}
+              readOnly
+              disabled
+              className="bg-muted"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="login-password">Password</Label>
+            <div className="relative">
+              <Input
+                id="login-password"
+                type={showPassword ? "text" : "password"}
+                value={loginPassword}
+                onChange={(e) => setLoginPassword(e.target.value)}
+                placeholder="••••••••"
+                className="pr-10"
+                required
+                autoComplete="current-password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus:outline-none"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-5 w-5" />
+                ) : (
+                  <Eye className="h-5 w-5" />
+                )}
+              </button>
+            </div>
+          </div>
+          <PrimaryButton type="submit" loading={actionLoading}>
+            Sign in
+          </PrimaryButton>
+        </form>
+      )}
+    </InviteShell>
+  );
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -10,6 +10,7 @@ import {
   authApi,
   getApiErrorMessage,
   invitesApi,
+  organizationsApi,
   setActiveOrgId,
   setAuthToken,
   type InvitePreview,
@@ -124,6 +125,7 @@ export default function InvitePage() {
   const token = params.token;
   const router = useRouter();
   const {
+    user,
     isAuthenticated,
     loading: authLoading,
     refreshUser,
@@ -190,11 +192,22 @@ export default function InvitePage() {
 
   const redirectAfterJoin = async (organizationId: number) => {
     setActiveOrgId(organizationId);
-    await refreshOrganizations();
-    await refreshUser();
+    const [meRes, orgsRes] = await Promise.all([
+      authApi.getMe(),
+      organizationsApi.getMine(),
+    ]);
+    await Promise.all([refreshUser(), refreshOrganizations()]);
+    const joinedOrg = orgsRes.organizations.find(
+      (o) => Number(o.id) === organizationId,
+    );
     router.push(
       defaultPostLoginPath(
-        buildNavAccess({ globalRole: "user" }),
+        buildNavAccess({
+          permissions: joinedOrg?.permissions ?? [],
+          isOwner:
+            orgsRes.is_super_admin || joinedOrg?.role_type === "owner",
+          globalRole: meRes.user.role,
+        }),
       ),
     );
   };
@@ -367,16 +380,32 @@ export default function InvitePage() {
       <InviteSummary preview={preview} />
       {actionError && <ErrorAlert message={actionError} />}
       {isAuthenticated ? (
-        <div className="space-y-4">
-          <p className="text-sm text-muted-foreground">
-            You&apos;re signed in. Accept this invite to join{" "}
-            <span className="font-medium text-foreground">{preview.org_name}</span>{" "}
-            as <span className="font-medium text-foreground">{preview.role_name}</span>.
-          </p>
-          <PrimaryButton loading={actionLoading} onClick={() => void handleAccept()}>
-            Accept invite
-          </PrimaryButton>
-        </div>
+        user?.email.toLowerCase() !== preview.email.toLowerCase() ? (
+          <div className="space-y-4">
+            <ErrorAlert
+              message={`This invite is for ${preview.email}, but you're signed in as ${user?.email}. Log out and sign in with the invited account to accept.`}
+            />
+            <PrimaryButton
+              onClick={() => {
+                setAuthToken(null);
+                void refreshUser();
+              }}
+            >
+              Log out
+            </PrimaryButton>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              You&apos;re signed in. Accept this invite to join{" "}
+              <span className="font-medium text-foreground">{preview.org_name}</span>{" "}
+              as <span className="font-medium text-foreground">{preview.role_name}</span>.
+            </p>
+            <PrimaryButton loading={actionLoading} onClick={() => void handleAccept()}>
+              Accept invite
+            </PrimaryButton>
+          </div>
+        )
       ) : (
         <form className="space-y-4 md:space-y-6" onSubmit={handleLogin}>
           <p className="text-sm text-muted-foreground">

--- a/src/app/settings/organization/page.tsx
+++ b/src/app/settings/organization/page.tsx
@@ -7,6 +7,7 @@ import { useOrganization } from "@/contexts/organization-context";
 import {
   organizationsApi,
   getApiErrorMessage,
+  type OrganizationInvite,
   type OrganizationMember,
   type OrganizationRole,
 } from "@/lib/api";
@@ -20,6 +21,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -27,6 +30,55 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const MODULE_MATRIX: ReadonlyArray<{
+  key: string;
+  label: string;
+  actions: readonly string[];
+}> = [
+  { key: "sales", label: "Sales", actions: ["read", "create", "update", "delete"] },
+  { key: "projects", label: "Projects", actions: ["read", "create", "update", "delete"] },
+  { key: "tasks", label: "Tasks", actions: ["read", "create", "update", "delete"] },
+  { key: "products", label: "Products", actions: ["read", "create", "update", "delete"] },
+  { key: "accounts", label: "Accounts", actions: ["read", "create", "update", "delete"] },
+  { key: "invoices", label: "Invoices", actions: ["read", "create", "update", "delete"] },
+  { key: "hr", label: "HR / Workspace", actions: ["read", "create", "update", "delete"] },
+  { key: "customers", label: "Customers / CRM", actions: ["read", "create", "update", "delete"] },
+  { key: "settings", label: "Settings", actions: ["read", "update"] },
+];
+
+const CRUD_ACTIONS = ["read", "create", "update", "delete"] as const;
+
+function permName(resource: string, action: string) {
+  return `${resource}.${action}`;
+}
+
+function memberDisplayName(member: OrganizationMember) {
+  const name = [member.first_name, member.last_name].filter(Boolean).join(" ");
+  return name || member.email;
+}
 
 export default function OrganizationSettingsPage() {
   const { activeOrg, isOwner, isSuperAdmin } = useOrganization();
@@ -35,31 +87,52 @@ export default function OrganizationSettingsPage() {
     setTitle("Organization");
     return () => setTitle(null);
   }, [setTitle]);
+
   const orgId = activeOrg?.id ?? null;
   const canManage = isSuperAdmin || isOwner;
 
   const [members, setMembers] = useState<OrganizationMember[]>([]);
   const [roles, setRoles] = useState<OrganizationRole[]>([]);
+  const [invites, setInvites] = useState<OrganizationInvite[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const [newRoleName, setNewRoleName] = useState("");
+  const [selectedRoleId, setSelectedRoleId] = useState<number | null>(null);
+  const [editingRoleName, setEditingRoleName] = useState("");
+  const [editingPerms, setEditingPerms] = useState<Set<string>>(new Set());
+  const [permsLoading, setPermsLoading] = useState(false);
+
   const [newEmail, setNewEmail] = useState("");
   const [newRoleId, setNewRoleId] = useState<string>("");
-  const [busy, setBusy] = useState(false);
+
+  const [confirmRemoveMember, setConfirmRemoveMember] =
+    useState<OrganizationMember | null>(null);
+  const [confirmDeleteRole, setConfirmDeleteRole] =
+    useState<OrganizationRole | null>(null);
+
+  const selectedRole = roles.find((r) => r.id === selectedRoleId) ?? null;
+  const assignableRoles = roles.filter((role) => role.role_type !== "owner");
+  const pendingInvites = invites.filter((inv) => inv.status === "pending");
 
   const load = useCallback(async () => {
     if (!orgId) return;
     setError(null);
     try {
-      const [m, r] = await Promise.all([
+      const [m, r, i] = await Promise.all([
         organizationsApi.listMembers(orgId),
         organizationsApi.listRoles(orgId),
+        organizationsApi.listInvites(orgId),
       ]);
       setMembers(m.members);
       setRoles(r.roles);
-      if (!newRoleId && r.roles.length > 0) {
+      setInvites(i.invites);
+      setNewRoleId((prev) => {
+        if (prev) return prev;
         const defaultRole =
           r.roles.find((role) => role.role_type === "custom") ?? r.roles[0];
-        setNewRoleId(String(defaultRole.id));
-      }
+        return defaultRole ? String(defaultRole.id) : "";
+      });
     } catch (err) {
       setError(getApiErrorMessage(err, "Failed to load organization settings"));
     }
@@ -68,6 +141,36 @@ export default function OrganizationSettingsPage() {
   useEffect(() => {
     if (canManage) void load();
   }, [canManage, load]);
+
+  useEffect(() => {
+    if (!orgId || !selectedRole || selectedRole.role_type === "owner") {
+      setEditingPerms(new Set());
+      setEditingRoleName(selectedRole?.name ?? "");
+      return;
+    }
+    let cancelled = false;
+    setPermsLoading(true);
+    void (async () => {
+      try {
+        const res = await organizationsApi.getRolePermissions(
+          orgId,
+          selectedRole.id,
+        );
+        if (cancelled) return;
+        setEditingPerms(new Set(res.permissions.map((p) => p.name)));
+        setEditingRoleName(selectedRole.name);
+      } catch (err) {
+        if (!cancelled) {
+          setError(getApiErrorMessage(err, "Failed to load role permissions"));
+        }
+      } finally {
+        if (!cancelled) setPermsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, selectedRole]);
 
   if (!activeOrg) return null;
   if (!canManage) {
@@ -79,6 +182,95 @@ export default function OrganizationSettingsPage() {
       </PageShell>
     );
   }
+
+  const createRole = async () => {
+    if (!orgId || !newRoleName.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await organizationsApi.createRole(orgId, {
+        name: newRoleName.trim(),
+        permission_names: [],
+      });
+      setNewRoleName("");
+      await load();
+      setSelectedRoleId(res.role.id);
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Failed to create role"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveRole = async () => {
+    if (!orgId || !selectedRole || selectedRole.role_type === "owner") return;
+    setBusy(true);
+    setError(null);
+    try {
+      await organizationsApi.updateRole(orgId, selectedRole.id, {
+        name: editingRoleName.trim(),
+        permission_names: Array.from(editingPerms),
+      });
+      await load();
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Failed to save role"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const deleteRole = async (role: OrganizationRole) => {
+    if (!orgId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await organizationsApi.deleteRole(orgId, role.id);
+      setConfirmDeleteRole(null);
+      if (selectedRoleId === role.id) setSelectedRoleId(null);
+      await load();
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Failed to delete role"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const togglePerm = (name: string, checked: boolean) => {
+    setEditingPerms((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(name);
+      else next.delete(name);
+      return next;
+    });
+  };
+
+  const changeMemberRole = async (member: OrganizationMember, roleId: string) => {
+    if (!orgId) return;
+    setError(null);
+    try {
+      await organizationsApi.updateMember(orgId, member.user_id, {
+        role_id: Number(roleId),
+      });
+      await load();
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Failed to update member"));
+    }
+  };
+
+  const removeMember = async (member: OrganizationMember) => {
+    if (!orgId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await organizationsApi.removeMember(orgId, member.user_id);
+      setConfirmRemoveMember(null);
+      await load();
+    } catch (err) {
+      setError(getApiErrorMessage(err, "Failed to remove member"));
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const inviteMember = async () => {
     if (!orgId || !newEmail.trim() || !newRoleId) return;
@@ -98,31 +290,27 @@ export default function OrganizationSettingsPage() {
     }
   };
 
-  const changeMemberRole = async (member: OrganizationMember, roleId: string) => {
+  const resendInvite = async (invite: OrganizationInvite) => {
     if (!orgId) return;
+    setError(null);
     try {
-      await organizationsApi.updateMember(orgId, member.user_id, {
-        role_id: Number(roleId),
-      });
+      await organizationsApi.resendInvite(orgId, invite.id);
       await load();
     } catch (err) {
-      setError(getApiErrorMessage(err, "Failed to update member"));
+      setError(getApiErrorMessage(err, "Failed to resend invite"));
     }
   };
 
-  const toggleMemberActive = async (member: OrganizationMember) => {
+  const revokeInvite = async (invite: OrganizationInvite) => {
     if (!orgId) return;
+    setError(null);
     try {
-      await organizationsApi.updateMember(orgId, member.user_id, {
-        is_active: !member.is_active,
-      });
+      await organizationsApi.revokeInvite(orgId, invite.id);
       await load();
     } catch (err) {
-      setError(getApiErrorMessage(err, "Failed to update member"));
+      setError(getApiErrorMessage(err, "Failed to revoke invite"));
     }
   };
-
-  const assignableRoles = roles.filter((role) => role.role_type !== "owner");
 
   return (
     <PageShell>
@@ -133,98 +321,396 @@ export default function OrganizationSettingsPage() {
           </div>
         )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Members</CardTitle>
-            <CardDescription>
-              Invite users to {activeOrg.name} and assign a role.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <Input
-                type="email"
-                value={newEmail}
-                onChange={(e) => setNewEmail(e.target.value)}
-                placeholder="user@example.com"
-                className="max-w-xs"
-              />
-              <Select value={newRoleId} onValueChange={setNewRoleId}>
-                <SelectTrigger className="w-40">
-                  <SelectValue placeholder="Role" />
-                </SelectTrigger>
-                <SelectContent>
-                  {assignableRoles.map((role) => (
-                    <SelectItem key={role.id} value={String(role.id)}>
-                      {role.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button
-                size="sm"
-                onClick={inviteMember}
-                disabled={busy || !newEmail.trim() || !newRoleId}
-              >
-                Send invite
-              </Button>
-            </div>
+        <Tabs defaultValue="roles">
+          <TabsList>
+            <TabsTrigger value="roles">Roles</TabsTrigger>
+            <TabsTrigger value="members">Members</TabsTrigger>
+            <TabsTrigger value="invites">Invites</TabsTrigger>
+          </TabsList>
 
-            <div className="divide-y rounded-md border">
-              {members.map((m) => (
-                <div
-                  key={m.id}
-                  className="flex flex-wrap items-center justify-between gap-2 p-3"
-                >
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">
-                      {[m.first_name, m.last_name].filter(Boolean).join(" ") ||
-                        m.email}
-                    </div>
-                    <div className="truncate text-xs text-muted-foreground">
-                      {m.email}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {!m.is_active && <Badge variant="secondary">inactive</Badge>}
-                    {m.role_type === "owner" ? (
-                      <Badge>{m.role_name}</Badge>
-                    ) : (
-                      <Select
-                        value={String(m.role_id)}
-                        onValueChange={(roleId) => changeMemberRole(m, roleId)}
-                      >
-                        <SelectTrigger className="w-36">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {assignableRoles.map((role) => (
-                            <SelectItem key={role.id} value={String(role.id)}>
-                              {role.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    )}
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => toggleMemberActive(m)}
+          <TabsContent value="roles" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Roles</CardTitle>
+                <CardDescription>
+                  Create custom roles and set module permissions for {activeOrg.name}.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Input
+                    value={newRoleName}
+                    onChange={(e) => setNewRoleName(e.target.value)}
+                    placeholder="New role name"
+                    className="max-w-xs"
+                  />
+                  <Button
+                    size="sm"
+                    onClick={createRole}
+                    disabled={busy || !newRoleName.trim()}
+                  >
+                    Create role
+                  </Button>
+                </div>
+
+                <div className="divide-y rounded-md border">
+                  {roles.map((role) => (
+                    <button
+                      key={role.id}
+                      type="button"
+                      onClick={() => setSelectedRoleId(role.id)}
+                      className={`flex w-full items-center justify-between gap-2 p-3 text-left transition-colors hover:bg-muted/50 ${
+                        selectedRoleId === role.id ? "bg-muted/60" : ""
+                      }`}
                     >
-                      {m.is_active ? "Deactivate" : "Reactivate"}
-                    </Button>
+                      <span className="text-sm font-medium">{role.name}</span>
+                      {role.role_type === "owner" ? (
+                        <Badge variant="secondary">Owner · locked</Badge>
+                      ) : (
+                        <Badge variant="outline">Custom</Badge>
+                      )}
+                    </button>
+                  ))}
+                  {roles.length === 0 && (
+                    <div className="p-4 text-center text-sm text-muted-foreground">
+                      No roles yet.
+                    </div>
+                  )}
+                </div>
+
+                {selectedRole && (
+                  <div className="space-y-4 rounded-md border p-4">
+                    {selectedRole.role_type === "owner" ? (
+                      <p className="text-sm text-muted-foreground">
+                        The Owner role has full access to all modules and cannot be
+                        edited or deleted.
+                      </p>
+                    ) : (
+                      <>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Label htmlFor="role-name" className="sr-only">
+                            Role name
+                          </Label>
+                          <Input
+                            id="role-name"
+                            value={editingRoleName}
+                            onChange={(e) => setEditingRoleName(e.target.value)}
+                            className="max-w-xs"
+                          />
+                          <Button
+                            size="sm"
+                            onClick={saveRole}
+                            disabled={
+                              busy || permsLoading || !editingRoleName.trim()
+                            }
+                          >
+                            Save role
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => setConfirmDeleteRole(selectedRole)}
+                            disabled={busy}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+
+                        <div className="overflow-x-auto">
+                          <Table>
+                            <TableHeader>
+                              <TableRow>
+                                <TableHead>Module</TableHead>
+                                {CRUD_ACTIONS.map((action) => (
+                                  <TableHead key={action} className="text-center capitalize">
+                                    {action}
+                                  </TableHead>
+                                ))}
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {MODULE_MATRIX.map((mod) => (
+                                <TableRow key={mod.key}>
+                                  <TableCell className="font-medium">
+                                    {mod.label}
+                                  </TableCell>
+                                  {CRUD_ACTIONS.map((action) => {
+                                    const allowed = mod.actions.includes(action);
+                                    const name = permName(mod.key, action);
+                                    return (
+                                      <TableCell key={action} className="text-center">
+                                        {allowed ? (
+                                          <Checkbox
+                                            checked={editingPerms.has(name)}
+                                            disabled={permsLoading}
+                                            onCheckedChange={(checked) =>
+                                              togglePerm(name, checked === true)
+                                            }
+                                            aria-label={`${mod.label} ${action}`}
+                                          />
+                                        ) : (
+                                          <span className="text-muted-foreground">—</span>
+                                        )}
+                                      </TableCell>
+                                    );
+                                  })}
+                                </TableRow>
+                              ))}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      </>
+                    )}
+
+                    {selectedRole.role_type === "owner" && (
+                      <div className="overflow-x-auto">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Module</TableHead>
+                              {CRUD_ACTIONS.map((action) => (
+                                <TableHead key={action} className="text-center capitalize">
+                                  {action}
+                                </TableHead>
+                              ))}
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {MODULE_MATRIX.map((mod) => (
+                              <TableRow key={mod.key}>
+                                <TableCell className="font-medium">
+                                  {mod.label}
+                                </TableCell>
+                                {CRUD_ACTIONS.map((action) => {
+                                  const allowed = mod.actions.includes(action);
+                                  return (
+                                    <TableCell key={action} className="text-center">
+                                      {allowed ? (
+                                        <Checkbox checked disabled aria-hidden />
+                                      ) : (
+                                        <span className="text-muted-foreground">—</span>
+                                      )}
+                                    </TableCell>
+                                  );
+                                })}
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
                   </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="members">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Members</CardTitle>
+                <CardDescription>
+                  Manage who belongs to {activeOrg.name} and their assigned role.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="divide-y rounded-md border">
+                  {members.map((m) => (
+                    <div
+                      key={m.id}
+                      className="flex flex-wrap items-center justify-between gap-2 p-3"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">
+                          {memberDisplayName(m)}
+                        </div>
+                        <div className="truncate text-xs text-muted-foreground">
+                          {m.email}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {!m.is_active && (
+                          <Badge variant="secondary">inactive</Badge>
+                        )}
+                        {m.role_type === "owner" ? (
+                          <Badge>{m.role_name}</Badge>
+                        ) : (
+                          <Select
+                            value={String(m.role_id)}
+                            onValueChange={(roleId) => changeMemberRole(m, roleId)}
+                          >
+                            <SelectTrigger className="w-36">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {assignableRoles.map((role) => (
+                                <SelectItem key={role.id} value={String(role.id)}>
+                                  {role.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        )}
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => setConfirmRemoveMember(m)}
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                  {members.length === 0 && (
+                    <div className="p-4 text-center text-sm text-muted-foreground">
+                      No members yet.
+                    </div>
+                  )}
                 </div>
-              ))}
-              {members.length === 0 && (
-                <div className="p-4 text-center text-sm text-muted-foreground">
-                  No members yet.
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="invites" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Invites</CardTitle>
+                <CardDescription>
+                  Invite users by email. Pending invites expire after 30 days.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Input
+                    type="email"
+                    value={newEmail}
+                    onChange={(e) => setNewEmail(e.target.value)}
+                    placeholder="user@example.com"
+                    className="max-w-xs"
+                  />
+                  <Select value={newRoleId} onValueChange={setNewRoleId}>
+                    <SelectTrigger className="w-40">
+                      <SelectValue placeholder="Role" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {assignableRoles.map((role) => (
+                        <SelectItem key={role.id} value={String(role.id)}>
+                          {role.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    size="sm"
+                    onClick={inviteMember}
+                    disabled={busy || !newEmail.trim() || !newRoleId}
+                  >
+                    Send invite
+                  </Button>
                 </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+
+                <div className="divide-y rounded-md border">
+                  {pendingInvites.map((inv) => (
+                    <div
+                      key={inv.id}
+                      className="flex flex-wrap items-center justify-between gap-2 p-3"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{inv.email}</div>
+                        <div className="truncate text-xs text-muted-foreground">
+                          {inv.role_name ?? `Role #${inv.role_id}`} · expires{" "}
+                          {new Date(inv.expires_at).toLocaleDateString()}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => resendInvite(inv)}
+                        >
+                          Resend
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => revokeInvite(inv)}
+                        >
+                          Revoke
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                  {pendingInvites.length === 0 && (
+                    <div className="p-4 text-center text-sm text-muted-foreground">
+                      No pending invites.
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
       </div>
+
+      <Dialog
+        open={confirmRemoveMember != null}
+        onOpenChange={(open) => !open && setConfirmRemoveMember(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove member?</DialogTitle>
+            <DialogDescription>
+              {confirmRemoveMember
+                ? `${memberDisplayName(confirmRemoveMember)} will lose access to ${activeOrg.name}.`
+                : null}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmRemoveMember(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={busy}
+              onClick={() =>
+                confirmRemoveMember && void removeMember(confirmRemoveMember)
+              }
+            >
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={confirmDeleteRole != null}
+        onOpenChange={(open) => !open && setConfirmDeleteRole(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete role?</DialogTitle>
+            <DialogDescription>
+              {confirmDeleteRole
+                ? `The "${confirmDeleteRole.name}" role will be permanently deleted. Reassign any members first.`
+                : null}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDeleteRole(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={busy}
+              onClick={() => confirmDeleteRole && void deleteRole(confirmDeleteRole)}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </PageShell>
   );
 }

--- a/src/app/settings/organization/page.tsx
+++ b/src/app/settings/organization/page.tsx
@@ -8,7 +8,7 @@ import {
   organizationsApi,
   getApiErrorMessage,
   type OrganizationMember,
-  type OrgRolePermissionEntry,
+  type OrganizationRole,
 } from "@/lib/api";
 import {
   Card,
@@ -20,7 +20,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -29,39 +28,38 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const MEMBER_ROLES = ["admin", "staff", "customer"] as const;
-
 export default function OrganizationSettingsPage() {
-  const { activeOrg, orgRole, isSuperAdmin } = useOrganization();
+  const { activeOrg, isOwner, isSuperAdmin } = useOrganization();
   const { setTitle } = usePageTitle();
   useEffect(() => {
     setTitle("Organization");
     return () => setTitle(null);
   }, [setTitle]);
   const orgId = activeOrg?.id ?? null;
-  const canManage = isSuperAdmin || orgRole === "admin";
+  const canManage = isSuperAdmin || isOwner;
 
   const [members, setMembers] = useState<OrganizationMember[]>([]);
-  const [permissions, setPermissions] = useState<{
-    staff: OrgRolePermissionEntry[];
-    customer: OrgRolePermissionEntry[];
-  } | null>(null);
-  const [permRole, setPermRole] = useState<"staff" | "customer">("staff");
+  const [roles, setRoles] = useState<OrganizationRole[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [newEmail, setNewEmail] = useState("");
-  const [newRole, setNewRole] = useState<string>("staff");
+  const [newRoleId, setNewRoleId] = useState<string>("");
   const [busy, setBusy] = useState(false);
 
   const load = useCallback(async () => {
     if (!orgId) return;
     setError(null);
     try {
-      const [m, p] = await Promise.all([
+      const [m, r] = await Promise.all([
         organizationsApi.listMembers(orgId),
-        organizationsApi.getPermissions(orgId),
+        organizationsApi.listRoles(orgId),
       ]);
       setMembers(m.members);
-      setPermissions(p.roles);
+      setRoles(r.roles);
+      if (!newRoleId && r.roles.length > 0) {
+        const defaultRole =
+          r.roles.find((role) => role.role_type === "custom") ?? r.roles[0];
+        setNewRoleId(String(defaultRole.id));
+      }
     } catch (err) {
       setError(getApiErrorMessage(err, "Failed to load organization settings"));
     }
@@ -76,34 +74,36 @@ export default function OrganizationSettingsPage() {
     return (
       <PageShell>
         <div className="p-8 text-center text-muted-foreground">
-          Organization admin access required.
+          Organization owner access required.
         </div>
       </PageShell>
     );
   }
 
-  const addMember = async () => {
-    if (!orgId || !newEmail.trim()) return;
+  const inviteMember = async () => {
+    if (!orgId || !newEmail.trim() || !newRoleId) return;
     setBusy(true);
     setError(null);
     try {
-      await organizationsApi.addMember(orgId, {
+      await organizationsApi.createInvite(orgId, {
         email: newEmail.trim(),
-        role: newRole,
+        role_id: Number(newRoleId),
       });
       setNewEmail("");
       await load();
     } catch (err) {
-      setError(getApiErrorMessage(err, "Failed to add member"));
+      setError(getApiErrorMessage(err, "Failed to send invite"));
     } finally {
       setBusy(false);
     }
   };
 
-  const changeMemberRole = async (member: OrganizationMember, role: string) => {
+  const changeMemberRole = async (member: OrganizationMember, roleId: string) => {
     if (!orgId) return;
     try {
-      await organizationsApi.updateMember(orgId, member.id, { role });
+      await organizationsApi.updateMember(orgId, member.user_id, {
+        role_id: Number(roleId),
+      });
       await load();
     } catch (err) {
       setError(getApiErrorMessage(err, "Failed to update member"));
@@ -113,7 +113,7 @@ export default function OrganizationSettingsPage() {
   const toggleMemberActive = async (member: OrganizationMember) => {
     if (!orgId) return;
     try {
-      await organizationsApi.updateMember(orgId, member.id, {
+      await organizationsApi.updateMember(orgId, member.user_id, {
         is_active: !member.is_active,
       });
       await load();
@@ -122,24 +122,7 @@ export default function OrganizationSettingsPage() {
     }
   };
 
-  const toggleOverride = async (entry: OrgRolePermissionEntry) => {
-    if (!orgId) return;
-    // Cycle: effective on -> revoke; effective off -> grant. Clearing back to
-    // the default happens when the override matches the default again.
-    const nextGranted = !entry.effective;
-    const override = nextGranted === entry.default_granted ? null : nextGranted;
-    try {
-      await organizationsApi.setPermissions(orgId, {
-        role: permRole,
-        overrides: [{ permission_id: entry.id, granted: override }],
-      });
-      await load();
-    } catch (err) {
-      setError(getApiErrorMessage(err, "Failed to update permissions"));
-    }
-  };
-
-  const permEntries = permissions?.[permRole] ?? [];
+  const assignableRoles = roles.filter((role) => role.role_type !== "owner");
 
   return (
     <PageShell>
@@ -154,7 +137,7 @@ export default function OrganizationSettingsPage() {
           <CardHeader>
             <CardTitle className="text-base">Members</CardTitle>
             <CardDescription>
-              Add existing users to {activeOrg.name} and set their role.
+              Invite users to {activeOrg.name} and assign a role.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -166,24 +149,24 @@ export default function OrganizationSettingsPage() {
                 placeholder="user@example.com"
                 className="max-w-xs"
               />
-              <Select value={newRole} onValueChange={setNewRole}>
-                <SelectTrigger className="w-32">
-                  <SelectValue />
+              <Select value={newRoleId} onValueChange={setNewRoleId}>
+                <SelectTrigger className="w-40">
+                  <SelectValue placeholder="Role" />
                 </SelectTrigger>
                 <SelectContent>
-                  {MEMBER_ROLES.map((r) => (
-                    <SelectItem key={r} value={r}>
-                      {r}
+                  {assignableRoles.map((role) => (
+                    <SelectItem key={role.id} value={String(role.id)}>
+                      {role.name}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
               <Button
                 size="sm"
-                onClick={addMember}
-                disabled={busy || !newEmail.trim()}
+                onClick={inviteMember}
+                disabled={busy || !newEmail.trim() || !newRoleId}
               >
-                Add member
+                Send invite
               </Button>
             </div>
 
@@ -204,21 +187,25 @@ export default function OrganizationSettingsPage() {
                   </div>
                   <div className="flex items-center gap-2">
                     {!m.is_active && <Badge variant="secondary">inactive</Badge>}
-                    <Select
-                      value={m.role}
-                      onValueChange={(role) => changeMemberRole(m, role)}
-                    >
-                      <SelectTrigger className="w-28">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {MEMBER_ROLES.map((r) => (
-                          <SelectItem key={r} value={r}>
-                            {r}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    {m.role_type === "owner" ? (
+                      <Badge>{m.role_name}</Badge>
+                    ) : (
+                      <Select
+                        value={String(m.role_id)}
+                        onValueChange={(roleId) => changeMemberRole(m, roleId)}
+                      >
+                        <SelectTrigger className="w-36">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {assignableRoles.map((role) => (
+                            <SelectItem key={role.id} value={String(role.id)}>
+                              {role.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
                     <Button
                       size="sm"
                       variant="ghost"
@@ -232,63 +219,6 @@ export default function OrganizationSettingsPage() {
               {members.length === 0 && (
                 <div className="p-4 text-center text-sm text-muted-foreground">
                   No members yet.
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Role permissions</CardTitle>
-            <CardDescription>
-              Adjust what {permRole} members can do in this organization.
-              Admins always have full access. Checkboxes show the effective
-              permission; changes create org-level overrides.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <Select
-              value={permRole}
-              onValueChange={(v) => setPermRole(v as "staff" | "customer")}
-            >
-              <SelectTrigger className="w-40">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="staff">staff</SelectItem>
-                <SelectItem value="customer">customer</SelectItem>
-              </SelectContent>
-            </Select>
-
-            <div className="divide-y rounded-md border">
-              {permEntries.map((entry) => (
-                <label
-                  key={entry.id}
-                  className="flex cursor-pointer items-center justify-between gap-3 p-3"
-                >
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium">{entry.name}</div>
-                    {entry.description && (
-                      <div className="truncate text-xs text-muted-foreground">
-                        {entry.description}
-                      </div>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {entry.override !== null && (
-                      <Badge variant="outline">override</Badge>
-                    )}
-                    <Checkbox
-                      checked={entry.effective}
-                      onCheckedChange={() => toggleOverride(entry)}
-                    />
-                  </div>
-                </label>
-              ))}
-              {permEntries.length === 0 && (
-                <div className="p-4 text-center text-sm text-muted-foreground">
-                  No permissions defined.
                 </div>
               )}
             </div>

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -24,7 +24,9 @@ import {
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/auth-context";
+import { useOrganization } from "@/contexts/organization-context";
 import {
+  buildNavAccess,
   filterStaffOnlyModules,
   filterStaffOnlyQuickLinks,
 } from "@/lib/nav-access";
@@ -228,13 +230,23 @@ export function Dashboard({
   className,
 }: DashboardProps) {
   const { user } = useAuth();
+  const { permissions, isOwner } = useOrganization();
+  const navAccess = React.useMemo(
+    () =>
+      buildNavAccess({
+        permissions,
+        isOwner,
+        globalRole: user?.global_role,
+      }),
+    [permissions, isOwner, user?.global_role],
+  );
   const visibleQuickLinks = React.useMemo(
-    () => filterStaffOnlyQuickLinks(quickLinks, user?.role),
-    [quickLinks, user?.role],
+    () => filterStaffOnlyQuickLinks(quickLinks, navAccess),
+    [quickLinks, navAccess],
   );
   const visibleModules = React.useMemo(
-    () => filterStaffOnlyModules(modules, user?.role),
-    [modules, user?.role],
+    () => filterStaffOnlyModules(modules, navAccess),
+    [modules, navAccess],
   );
 
   return (

--- a/src/components/protected-route.tsx
+++ b/src/components/protected-route.tsx
@@ -6,8 +6,9 @@ import { useAuth } from "@/contexts/auth-context";
 import { useOrganization } from "@/contexts/organization-context";
 import { NoOrganizationScreen } from "@/components/org-switcher";
 import {
-  canAccessStaffRoutes,
-  isStaffOnlyPath,
+  buildNavAccess,
+  canAccessPath,
+  isClientPortalPath,
 } from "@/lib/nav-access";
 import { Loader2 } from "lucide-react";
 
@@ -15,18 +16,35 @@ interface ProtectedRouteProps {
   children: React.ReactNode;
 }
 
-const PUBLIC_ROUTES = ["/login", "/signup", "/customer-onboarding"];
+const PUBLIC_ROUTES = ["/login", "/signup", "/customer-onboarding", "/invite"];
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { user, isAuthenticated, loading } = useAuth();
-  const { activeOrg, isSuperAdmin, loaded: orgsLoaded } = useOrganization();
+  const {
+    activeOrg,
+    isSuperAdmin,
+    loaded: orgsLoaded,
+    permissions,
+    isOwner,
+  } = useOrganization();
   const router = useRouter();
   const pathname = usePathname();
+
+  const navAccess = buildNavAccess({
+    permissions,
+    isOwner,
+    globalRole: user?.global_role,
+  });
+
+  const pathAllowed =
+    !pathname ||
+    isClientPortalPath(pathname) ||
+    canAccessPath(pathname, navAccess);
 
   useEffect(() => {
     if (!loading && !isAuthenticated) {
       const isPublicRoute = PUBLIC_ROUTES.some((route) =>
-        pathname?.startsWith(route)
+        pathname?.startsWith(route),
       );
 
       if (!isPublicRoute) {
@@ -35,18 +53,11 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
       return;
     }
 
-    if (
-      !loading &&
-      isAuthenticated &&
-      pathname &&
-      !canAccessStaffRoutes(user?.role) &&
-      isStaffOnlyPath(pathname)
-    ) {
+    if (!loading && isAuthenticated && pathname && !pathAllowed) {
       router.replace("/dashboard");
     }
-  }, [isAuthenticated, loading, pathname, router, user?.role]);
+  }, [isAuthenticated, loading, pathname, pathAllowed, router]);
 
-  // Show loading state while checking authentication
   if (loading) {
     return (
       <div className="h-screen w-screen flex items-center justify-center bg-background">
@@ -55,10 +66,8 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     );
   }
 
-  // If not authenticated and trying to access protected route, don't render children
-  // (redirect will happen in useEffect)
   const isPublicRoute = PUBLIC_ROUTES.some((route) =>
-    pathname?.startsWith(route)
+    pathname?.startsWith(route),
   );
 
   if (!isAuthenticated && !isPublicRoute) {
@@ -69,12 +78,7 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     );
   }
 
-  if (
-    isAuthenticated &&
-    pathname &&
-    !canAccessStaffRoutes(user?.role) &&
-    isStaffOnlyPath(pathname)
-  ) {
+  if (isAuthenticated && pathname && !pathAllowed) {
     return (
       <div className="h-screen w-screen flex items-center justify-center bg-background">
         <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
@@ -82,8 +86,6 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     );
   }
 
-  // Authenticated users without any org membership can't load org-scoped
-  // data — show a clear notice instead of a wall of failed requests.
   const isPublic = PUBLIC_ROUTES.some((route) => pathname?.startsWith(route));
   if (
     isAuthenticated &&
@@ -97,4 +99,3 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   return <>{children}</>;
 }
-

--- a/src/components/sidenav.tsx
+++ b/src/components/sidenav.tsx
@@ -52,7 +52,12 @@ import {
 import { cn } from "@/lib/utils";
 import { useSidebar } from "@/contexts/sidebar-context";
 import { useAuth } from "@/contexts/auth-context";
-import { canAccessStaffRoutes, filterByStaffAccess } from "@/lib/nav-access";
+import { useOrganization } from "@/contexts/organization-context";
+import {
+  buildNavAccess,
+  canAccessInternalNav,
+  filterByNavAccess,
+} from "@/lib/nav-access";
 import {
   CLIENT_PORTAL_MENU_ITEMS,
   PORTAL_RESOURCES_HREF,
@@ -350,8 +355,8 @@ const CLIENT_SETTINGS_MENU_ITEMS: MenuItem[] = [
   },
 ];
 
-function getSettingsMenuItems(role?: string | null): MenuItem[] {
-  return canAccessStaffRoutes(role)
+function getSettingsMenuItems(access: ReturnType<typeof buildNavAccess>) {
+  return canAccessInternalNav(access)
     ? SETTINGS_MENU_ITEMS
     : CLIENT_SETTINGS_MENU_ITEMS;
 }
@@ -396,6 +401,16 @@ export default function SideNav() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { user } = useAuth();
+  const { permissions, isOwner } = useOrganization();
+  const navAccess = useMemo(
+    () =>
+      buildNavAccess({
+        permissions,
+        isOwner,
+        globalRole: user?.global_role,
+      }),
+    [permissions, isOwner, user?.global_role],
+  );
   const { isCollapsed, toggleSidebar } = useSidebar();
   const [activeItem, setActiveItem] = useState<string>("");
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
@@ -405,7 +420,7 @@ export default function SideNav() {
     { heading: string; items: string[] }[]
   >([]);
   const [aboutNotesLoading, setAboutNotesLoading] = useState(false);
-  const isClientPortalUser = !canAccessStaffRoutes(user?.role);
+  const isClientPortalUser = !canAccessInternalNav(navAccess);
 
   useEffect(() => {
     if (!aboutOpen) return;
@@ -437,11 +452,11 @@ export default function SideNav() {
   }, [aboutOpen]);
 
   const allMenuItems = useMemo(() => {
-    if (!canAccessStaffRoutes(user?.role)) {
+    if (!canAccessInternalNav(navAccess)) {
       return CLIENT_PORTAL_MENU_ITEMS;
     }
-    return filterByStaffAccess(MAIN_MENU_ITEMS, user?.role);
-  }, [user?.role]);
+    return filterByNavAccess(MAIN_MENU_ITEMS, navAccess);
+  }, [navAccess]);
 
   // When on /projects or /tasks, show Projects and Tasks in sidebar
   const isProjectsPage =
@@ -491,7 +506,7 @@ export default function SideNav() {
   } else if (isWorkspacePage) {
     menuItems = WORKSPACE_MENU_ITEMS;
   } else if (isSettingsPage) {
-    menuItems = getSettingsMenuItems(user?.role);
+    menuItems = getSettingsMenuItems(navAccess);
   } else {
     menuItems = allMenuItems;
   }
@@ -617,7 +632,7 @@ export default function SideNav() {
     }
 
     if (isSettingsPage) {
-      const currentSettingsItems = getSettingsMenuItems(user?.role);
+      const currentSettingsItems = getSettingsMenuItems(navAccess);
       const section = searchParams.get("section") || "general";
       const settingsItem = currentSettingsItems.find((item) =>
         item.href.includes(`section=${section}`),
@@ -639,7 +654,7 @@ export default function SideNav() {
     isEmployeeManagementSection,
     isWorkspacePage,
     isSettingsPage,
-    user?.role,
+    navAccess,
     searchParams,
   ]);
 

--- a/src/components/sidenav.tsx
+++ b/src/components/sidenav.tsx
@@ -355,10 +355,21 @@ const CLIENT_SETTINGS_MENU_ITEMS: MenuItem[] = [
   },
 ];
 
+const ORG_TEAM_SETTINGS_ITEM: MenuItem = {
+  id: "settings-organization-team",
+  label: "Organization",
+  icon: Users,
+  href: "/settings/organization",
+};
+
 function getSettingsMenuItems(access: ReturnType<typeof buildNavAccess>) {
-  return canAccessInternalNav(access)
+  const base = canAccessInternalNav(access)
     ? SETTINGS_MENU_ITEMS
     : CLIENT_SETTINGS_MENU_ITEMS;
+  if (access.isOwner) {
+    return [ORG_TEAM_SETTINGS_ITEM, ...base];
+  }
+  return base;
 }
 
 const ACCOUNTS_MENU_ITEMS: MenuItem[] = [
@@ -633,6 +644,13 @@ export default function SideNav() {
 
     if (isSettingsPage) {
       const currentSettingsItems = getSettingsMenuItems(navAccess);
+      if (pathname?.startsWith("/settings/organization")) {
+        const orgItem = currentSettingsItems.find(
+          (item) => item.href === "/settings/organization",
+        );
+        setActiveItem(orgItem?.id || currentSettingsItems[0]?.id || "");
+        return;
+      }
       const section = searchParams.get("section") || "general";
       const settingsItem = currentSettingsItems.find((item) =>
         item.href.includes(`section=${section}`),

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -8,7 +8,7 @@ import React, {
   ReactNode,
 } from "react";
 import { authApi, setAuthToken, type User } from "@/lib/api";
-import { defaultPostLoginPath } from "@/lib/nav-access";
+import { buildNavAccess, defaultPostLoginPath } from "@/lib/nav-access";
 import {
   effectiveRole,
   OrganizationProvider,
@@ -87,7 +87,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const response = await authApi.login({ email, password });
       setAuthToken(response.token);
       setUser(response.user);
-      router.push(defaultPostLoginPath(response.user.role));
+      router.push(
+        defaultPostLoginPath(
+          buildNavAccess({ globalRole: response.user.role }),
+        ),
+      );
     } catch (error) {
       console.error("Login failed:", error);
       throw error;
@@ -113,7 +117,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
       setAuthToken(response.token);
       setUser(response.user);
-      router.push(defaultPostLoginPath(response.user.role));
+      router.push(
+        defaultPostLoginPath(
+          buildNavAccess({ globalRole: response.user.role }),
+        ),
+      );
     } catch (error) {
       console.error("Signup failed:", error);
       throw error;
@@ -172,14 +180,27 @@ function EffectiveAuthProvider({
   refreshUser: AuthContextType["refreshUser"];
   children: ReactNode;
 }) {
-  const { isSuperAdmin, orgRole, loaded } = useOrganization();
+  const {
+    isSuperAdmin,
+    roleType,
+    permissions,
+    isOwner,
+    loaded,
+  } = useOrganization();
 
   const user: EffectiveUser | null = rawUser
     ? {
-      ...rawUser,
-      role: loaded ? effectiveRole(isSuperAdmin, orgRole) : rawUser.role,
-      global_role: rawUser.role,
-    }
+        ...rawUser,
+        role: loaded
+          ? effectiveRole(
+              isSuperAdmin,
+              roleType,
+              permissions,
+              rawUser.role,
+            )
+          : rawUser.role,
+        global_role: rawUser.role,
+      }
     : null;
 
   return (

--- a/src/contexts/organization-context.tsx
+++ b/src/contexts/organization-context.tsx
@@ -4,10 +4,8 @@
  * Organization (multi-tenancy) context.
  *
  * Loads the caller's memberships, keeps the active organization in
- * localStorage (sent as X-Organization-Id by lib/api), and exposes the
- * caller's role within the active org. AuthProvider consumes this to
- * present `user.role` as the effective org role, so existing role-gated
- * UI keeps working unchanged.
+ * localStorage (sent as X-Organization-Id by lib/api), and exposes
+ * role + permission data for the active org.
  */
 import React, {
   createContext,
@@ -22,15 +20,18 @@ import {
   organizationsApi,
   setActiveOrgId,
   type OrganizationSummary,
+  type OrgRoleType,
 } from "@/lib/api";
-
-export type OrgRole = "admin" | "staff" | "customer";
 
 interface OrganizationContextType {
   organizations: OrganizationSummary[];
   activeOrg: OrganizationSummary | null;
-  /** Role within the active org; null when the user has no membership. */
-  orgRole: OrgRole | null;
+  /** Effective permissions for the active org membership. */
+  permissions: string[];
+  roleType: OrgRoleType | null;
+  roleName: string | null;
+  roleId: number | null;
+  isOwner: boolean;
   isSuperAdmin: boolean;
   loading: boolean;
   /** True once memberships have been loaded for an authenticated user. */
@@ -89,8 +90,6 @@ export function OrganizationProvider({
   }, [applyOrgs]);
 
   useEffect(() => {
-    // Wait for auth to resolve. Clearing active_org_id while auth is still
-    // loading would wipe a just-switched org on every full page reload.
     if (authLoading) return;
 
     if (authenticated) {
@@ -111,8 +110,6 @@ export function OrganizationProvider({
       if (!target) return;
       setActiveOrgId(id);
       setActiveOrg(target);
-      // Full reload: every fetched dataset is org-scoped, so a clean
-      // slate beats invalidating every cache by hand.
       if (typeof window !== "undefined") {
         window.location.reload();
       }
@@ -120,14 +117,19 @@ export function OrganizationProvider({
     [organizations],
   );
 
-  const orgRole = (activeOrg?.role ?? null) as OrgRole | null;
+  const roleType = activeOrg?.role_type ?? null;
+  const isOwner = isSuperAdmin || roleType === "owner";
 
   return (
     <OrganizationContext.Provider
       value={{
         organizations,
         activeOrg,
-        orgRole,
+        permissions: activeOrg?.permissions ?? [],
+        roleType,
+        roleName: activeOrg?.role_name ?? null,
+        roleId: activeOrg?.role_id ?? null,
+        isOwner,
         isSuperAdmin,
         loading,
         loaded,
@@ -150,11 +152,18 @@ export function useOrganization() {
   return context;
 }
 
-/** Effective role for legacy role-gated UI: super admins act as org admins. */
+/** Legacy effective role string for components not yet on permission checks. */
 export function effectiveRole(
   isSuperAdmin: boolean,
-  orgRole: OrgRole | null,
+  roleType: OrgRoleType | null,
+  permissions: string[],
+  globalRole?: string | null,
 ): string {
-  if (isSuperAdmin) return "admin";
-  return orgRole ?? "user";
+  if (isSuperAdmin || roleType === "owner") return "admin";
+  if (permissions.some((p) => p.endsWith(".read"))) return "staff";
+  return normalizeGlobalRole(globalRole);
+}
+
+function normalizeGlobalRole(role?: string | null): string {
+  return (role ?? "user").toLowerCase();
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -144,7 +144,8 @@ async function fetchApi<T>(
       if (
         typeof window !== "undefined" &&
         !window.location.pathname.startsWith("/login") &&
-        !window.location.pathname.startsWith("/signup")
+        !window.location.pathname.startsWith("/signup") &&
+        !window.location.pathname.startsWith("/invite")
       ) {
         window.location.href = "/login";
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -216,19 +216,26 @@ export interface AuthResponse {
   token: string;
 }
 
+export type OrgRoleType = "owner" | "custom";
+
 export interface OrganizationSummary {
   id: number;
   name: string;
   slug: string;
   is_active: boolean;
-  role: "admin" | "staff" | "customer";
+  role_id: number | null;
+  role_type: OrgRoleType;
+  role_name: string;
+  permissions: string[];
   member_count?: number;
 }
 
 export interface OrganizationMember {
   id: number;
   user_id: number;
-  role: "admin" | "staff" | "customer";
+  role_id: number;
+  role_type: OrgRoleType;
+  role_name: string;
   is_active: boolean;
   email: string;
   first_name?: string | null;
@@ -236,15 +243,52 @@ export interface OrganizationMember {
   created_at?: string;
 }
 
-export interface OrgRolePermissionEntry {
+export interface OrganizationRole {
+  id: number;
+  organization_id: number;
+  name: string;
+  description?: string | null;
+  role_type: OrgRoleType;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OrgRolePermission {
   id: number;
   name: string;
   description?: string | null;
   resource: string;
   action: string;
-  default_granted: boolean;
-  override: boolean | null;
-  effective: boolean;
+}
+
+export type OrganizationInviteStatus =
+  | "pending"
+  | "accepted"
+  | "revoked"
+  | "expired";
+
+export interface OrganizationInvite {
+  id: number;
+  organization_id: number;
+  email: string;
+  role_id: number;
+  role_name?: string;
+  token: string;
+  invited_by: number;
+  status: OrganizationInviteStatus;
+  expires_at: string;
+  accepted_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InvitePreview {
+  org_name: string;
+  role_name: string;
+  email: string;
+  flow_type: "signup" | "accept";
+  expires_at: string;
+  status: OrganizationInviteStatus;
 }
 
 export const organizationsApi = {
@@ -290,22 +334,12 @@ export const organizationsApi = {
     return fetchApi(`/api/organizations/${orgId}/members`);
   },
 
-  addMember: async (
-    orgId: number,
-    input: { email: string; role: string },
-  ): Promise<{ member: OrganizationMember }> => {
-    return fetchApi(`/api/organizations/${orgId}/members`, {
-      method: "POST",
-      body: JSON.stringify(input),
-    });
-  },
-
   updateMember: async (
     orgId: number,
-    memberId: number,
-    input: { role?: string; is_active?: boolean },
+    userId: number,
+    input: { role_id?: number; is_active?: boolean },
   ): Promise<{ member: OrganizationMember }> => {
-    return fetchApi(`/api/organizations/${orgId}/members/${memberId}`, {
+    return fetchApi(`/api/organizations/${orgId}/members/${userId}`, {
       method: "PUT",
       body: JSON.stringify(input),
     });
@@ -313,30 +347,141 @@ export const organizationsApi = {
 
   removeMember: async (
     orgId: number,
-    memberId: number,
+    userId: number,
   ): Promise<{ success: boolean }> => {
-    return fetchApi(`/api/organizations/${orgId}/members/${memberId}`, {
+    return fetchApi(`/api/organizations/${orgId}/members/${userId}`, {
       method: "DELETE",
     });
   },
 
-  getPermissions: async (orgId: number): Promise<{
-    organization_id: number;
-    roles: { staff: OrgRolePermissionEntry[]; customer: OrgRolePermissionEntry[] };
-  }> => {
-    return fetchApi(`/api/organizations/${orgId}/permissions`);
+  listRoles: async (
+    orgId: number,
+  ): Promise<{ roles: OrganizationRole[] }> => {
+    return fetchApi(`/api/organizations/${orgId}/roles`);
   },
 
-  setPermissions: async (
+  createRole: async (
     orgId: number,
     input: {
-      role: "staff" | "customer";
-      overrides: Array<{ permission_id: number; granted: boolean | null }>;
+      name: string;
+      description?: string;
+      permission_names?: string[];
     },
-  ): Promise<{ success: boolean }> => {
-    return fetchApi(`/api/organizations/${orgId}/permissions`, {
+  ): Promise<{ role: OrganizationRole }> => {
+    return fetchApi(`/api/organizations/${orgId}/roles`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  },
+
+  updateRole: async (
+    orgId: number,
+    roleId: number,
+    input: {
+      name?: string;
+      description?: string;
+      permission_names?: string[];
+    },
+  ): Promise<{ role: OrganizationRole }> => {
+    return fetchApi(`/api/organizations/${orgId}/roles/${roleId}`, {
       method: "PUT",
       body: JSON.stringify(input),
+    });
+  },
+
+  deleteRole: async (
+    orgId: number,
+    roleId: number,
+  ): Promise<{ success: boolean }> => {
+    return fetchApi(`/api/organizations/${orgId}/roles/${roleId}`, {
+      method: "DELETE",
+    });
+  },
+
+  getRolePermissions: async (
+    orgId: number,
+    roleId: number,
+  ): Promise<{ role_id: number; permissions: OrgRolePermission[] }> => {
+    return fetchApi(
+      `/api/organizations/${orgId}/roles/${roleId}/permissions`,
+    );
+  },
+
+  setRolePermissions: async (
+    orgId: number,
+    roleId: number,
+    permissionNames: string[],
+  ): Promise<{ role_id: number; permissions: OrgRolePermission[] }> => {
+    return fetchApi(
+      `/api/organizations/${orgId}/roles/${roleId}/permissions`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ permission_names: permissionNames }),
+      },
+    );
+  },
+
+  listInvites: async (
+    orgId: number,
+  ): Promise<{ invites: OrganizationInvite[] }> => {
+    return fetchApi(`/api/organizations/${orgId}/invites`);
+  },
+
+  createInvite: async (
+    orgId: number,
+    input: { email: string; role_id: number },
+  ): Promise<{ invite: OrganizationInvite }> => {
+    return fetchApi(`/api/organizations/${orgId}/invites`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  },
+
+  resendInvite: async (
+    orgId: number,
+    inviteId: number,
+  ): Promise<{ invite: OrganizationInvite }> => {
+    return fetchApi(
+      `/api/organizations/${orgId}/invites/${inviteId}/resend`,
+      { method: "POST" },
+    );
+  },
+
+  revokeInvite: async (
+    orgId: number,
+    inviteId: number,
+  ): Promise<{ invite: OrganizationInvite }> => {
+    return fetchApi(
+      `/api/organizations/${orgId}/invites/${inviteId}/revoke`,
+      { method: "POST" },
+    );
+  },
+};
+
+export const invitesApi = {
+  preview: async (token: string): Promise<InvitePreview> => {
+    return fetchApi(`/api/invites/${encodeURIComponent(token)}`);
+  },
+
+  signup: async (
+    token: string,
+    body: { name?: string; password: string },
+  ): Promise<{
+    user: { id: number; email: string; first_name?: string | null };
+    token: string;
+    organization_id: number;
+  }> => {
+    return fetchApi(`/api/invites/${encodeURIComponent(token)}/signup`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  },
+
+  accept: async (
+    token: string,
+  ): Promise<{ success: boolean; organization_id: number; role_id: number }> => {
+    return fetchApi(`/api/invites/${encodeURIComponent(token)}/accept`, {
+      method: "POST",
     });
   },
 };

--- a/src/lib/nav-access.ts
+++ b/src/lib/nav-access.ts
@@ -1,82 +1,48 @@
 /**
- * Navigation and route access for role `user` vs `staff` / `admin`.
- * Regular users see the client portal sidebar; settings is in the top nav.
+ * Navigation and route access driven by org-scoped permissions.
+ * Owner (and super admin acting as owner) bypasses all module checks.
  */
 
-export const STAFF_ONLY_MENU_IDS = new Set([
-  "customers",
-  "projects",
-  "tasks",
-  "products",
-  "hiring",
-  "accounts",
-  "invoices",
-  "workspace",
-  "human-resource",
-  "settings",
-  "crm",
-  "human-resources",
-]);
+export interface NavAccess {
+  permissions: string[];
+  isOwner: boolean;
+  /** Global account role (`user`, `super_admin`, etc.). */
+  globalRole?: string | null;
+}
 
-const STAFF_ONLY_PATH_PREFIXES = [
-  "/sales",
-  "/customer-onboarding",
-  "/projects",
-  "/tasks",
-  "/products",
-  "/product",
-  "/accounts",
-  "/workspace",
-  "/hr",
-  "/hiring",
-  "/invoices",
-] as const;
+/** Sidebar / launcher menu id → required permission (usually resource.read). */
+export const MENU_PERMISSION: Record<string, string | null> = {
+  dashboard: null,
+  customers: "sales.read",
+  projects: "projects.read",
+  tasks: "tasks.read",
+  products: "products.read",
+  hiring: "hr.read",
+  accounts: "accounts.read",
+  invoices: "invoices.read",
+  workspace: "hr.read",
+  "human-resource": "hr.read",
+  "human-resources": "hr.read",
+  settings: "settings.read",
+  crm: "customers.read",
+};
 
-/** Paths reserved for the client portal — allowed for role `user`. */
+const PATH_PERMISSION_RULES: ReadonlyArray<readonly [string, string]> = [
+  ["/sales", "sales.read"],
+  ["/customer-onboarding", "sales.read"],
+  ["/projects", "projects.read"],
+  ["/tasks", "tasks.read"],
+  ["/products", "products.read"],
+  ["/product", "products.read"],
+  ["/accounts", "accounts.read"],
+  ["/workspace", "hr.read"],
+  ["/hr", "hr.read"],
+  ["/hiring", "hr.read"],
+  ["/invoices", "invoices.read"],
+  ["/settings", "settings.read"],
+];
+
 const CLIENT_PORTAL_PATH_PREFIXES = ["/portal"] as const;
-
-export function isClientPortalPath(pathname: string): boolean {
-  return (
-    pathname === "/dashboard" ||
-    CLIENT_PORTAL_PATH_PREFIXES.some(
-      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-    )
-  );
-}
-
-export function normalizeRole(role?: string | null): string {
-  return (role ?? "user").toLowerCase();
-}
-
-export function canAccessStaffRoutes(role?: string | null): boolean {
-  const normalized = normalizeRole(role);
-  return normalized === "admin" || normalized === "staff";
-}
-
-/** Home page is the applications launcher — staff/admin only. */
-export function isApplicationsHomePath(pathname: string): boolean {
-  return pathname === "/";
-}
-
-export function isStaffOnlyPath(pathname: string): boolean {
-  if (isApplicationsHomePath(pathname)) return true;
-  if (isClientPortalPath(pathname)) return false;
-  return STAFF_ONLY_PATH_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
-}
-
-export function filterByStaffAccess<T extends { id: string }>(
-  items: T[],
-  role?: string | null,
-): T[] {
-  if (canAccessStaffRoutes(role)) return items;
-  return items.filter((item) => !STAFF_ONLY_MENU_IDS.has(item.id));
-}
-
-export function defaultPostLoginPath(role?: string | null): string {
-  return canAccessStaffRoutes(role) ? "/" : "/dashboard";
-}
 
 const STAFF_ONLY_QUICK_LINK_HREFS = new Set([
   "/sales/deals",
@@ -90,6 +56,135 @@ const STAFF_ONLY_QUICK_LINK_HREFS = new Set([
 
 const STAFF_ONLY_QUICK_LINK_PREFIXES = ["/hr"] as const;
 
+export function hasPermission(
+  permissions: string[] | undefined,
+  name: string,
+): boolean {
+  return (permissions ?? []).includes(name);
+}
+
+export function normalizeRole(role?: string | null): string {
+  return (role ?? "user").toLowerCase();
+}
+
+export function buildNavAccess(input: {
+  permissions?: string[];
+  isOwner?: boolean;
+  globalRole?: string | null;
+}): NavAccess {
+  return {
+    permissions: input.permissions ?? [],
+    isOwner: input.isOwner ?? false,
+    globalRole: input.globalRole ?? null,
+  };
+}
+
+/** True when the user can see internal (non-portal) navigation at all. */
+export function canAccessInternalNav(access: NavAccess): boolean {
+  if (access.isOwner) return true;
+  if (normalizeRole(access.globalRole) === "super_admin") return true;
+  return access.permissions.some((p) => p.endsWith(".read"));
+}
+
+export function canAccessMenuItem(menuId: string, access: NavAccess): boolean {
+  if (access.isOwner) return true;
+  const required = MENU_PERMISSION[menuId];
+  if (required === null || required === undefined) {
+    return canAccessInternalNav(access);
+  }
+  return hasPermission(access.permissions, required);
+}
+
+export function isClientPortalPath(pathname: string): boolean {
+  return (
+    pathname === "/dashboard" ||
+    CLIENT_PORTAL_PATH_PREFIXES.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    )
+  );
+}
+
+export function isApplicationsHomePath(pathname: string): boolean {
+  return pathname === "/";
+}
+
+function pathRequiredPermission(pathname: string): string | null {
+  for (const [prefix, permission] of PATH_PERMISSION_RULES) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      return permission;
+    }
+  }
+  return null;
+}
+
+export function canAccessPath(pathname: string, access: NavAccess): boolean {
+  if (access.isOwner || normalizeRole(access.globalRole) === "super_admin") {
+    return true;
+  }
+
+  if (isClientPortalPath(pathname)) {
+    return (
+      normalizeRole(access.globalRole) === "user" ||
+      hasPermission(access.permissions, "projects.read")
+    );
+  }
+
+  if (isApplicationsHomePath(pathname)) {
+    return canAccessInternalNav(access);
+  }
+
+  const required = pathRequiredPermission(pathname);
+  if (required === null) {
+    return canAccessInternalNav(access);
+  }
+  return hasPermission(access.permissions, required);
+}
+
+export function isStaffOnlyPath(pathname: string, access?: NavAccess): boolean {
+  if (isApplicationsHomePath(pathname)) return true;
+  if (isClientPortalPath(pathname)) return false;
+  if (access) {
+    return !canAccessPath(pathname, access);
+  }
+  return PATH_PERMISSION_RULES.some(
+    ([prefix]) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/** @deprecated Prefer `canAccessInternalNav(buildNavAccess(...))`. */
+export function canAccessStaffRoutes(role?: string | null): boolean {
+  const normalized = normalizeRole(role);
+  return normalized === "admin" || normalized === "staff";
+}
+
+export function filterByNavAccess<T extends { id: string }>(
+  items: T[],
+  access: NavAccess,
+): T[] {
+  if (access.isOwner || normalizeRole(access.globalRole) === "super_admin") {
+    return items;
+  }
+  return items.filter((item) => canAccessMenuItem(item.id, access));
+}
+
+/** @deprecated Prefer `filterByNavAccess` with org permissions. */
+export function filterByStaffAccess<T extends { id: string }>(
+  items: T[],
+  role?: string | null,
+): T[] {
+  if (canAccessStaffRoutes(role)) return items;
+  const staffOnlyIds = new Set(
+    Object.entries(MENU_PERMISSION)
+      .filter(([, perm]) => perm !== null)
+      .map(([id]) => id),
+  );
+  return items.filter((item) => !staffOnlyIds.has(item.id));
+}
+
+export function defaultPostLoginPath(access: NavAccess): string {
+  return canAccessInternalNav(access) ? "/" : "/dashboard";
+}
+
 export function isStaffOnlyQuickLinkHref(href: string): boolean {
   if (STAFF_ONLY_QUICK_LINK_HREFS.has(href)) return true;
   return STAFF_ONLY_QUICK_LINK_PREFIXES.some(
@@ -99,17 +194,22 @@ export function isStaffOnlyQuickLinkHref(href: string): boolean {
 
 export function filterStaffOnlyQuickLinks<T extends { href: string }>(
   items: T[],
-  role?: string | null,
+  access: NavAccess,
 ): T[] {
-  if (canAccessStaffRoutes(role)) return items;
+  if (access.isOwner || canAccessInternalNav(access)) {
+    if (access.isOwner) return items;
+    return items.filter((item) => {
+      const required = pathRequiredPermission(item.href.split("?")[0] ?? "");
+      if (!required) return true;
+      return hasPermission(access.permissions, required);
+    });
+  }
   return items.filter((item) => !isStaffOnlyQuickLinkHref(item.href));
 }
 
 export function filterStaffOnlyModules<T extends { id: string }>(
   items: T[],
-  role?: string | null,
+  access: NavAccess,
 ): T[] {
-  if (canAccessStaffRoutes(role)) return items;
-  const staffOnlyModuleIds = new Set(["sales", "projects", "accounts"]);
-  return items.filter((item) => !staffOnlyModuleIds.has(item.id));
+  return filterByNavAccess(items, access);
 }


### PR DESCRIPTION
## Summary

- **Org context**: `OrganizationProvider` loads memberships, active org, role type, and permissions on login; persists active org in localStorage
- **Permission-aware nav gating**: `buildNavAccess` and `canAccessPath` gate sidebar items and routes by org permissions; `ProtectedRoute` redirects unauthorized users
- **Org settings page** (`/settings/organization`): members tab, roles tab (custom role builder with module/action matrix), invites tab
- **Org switcher**: dropdown for multi-org users; hidden for single-org members
- **Invite flow**: `/invite/[token]` landing page handles accept (logged-in) and signup (new user) flows
- **`NoOrganizationScreen`**: shown for authenticated users with no org membership

## Test plan

- [ ] Login as Owner — all nav items visible, org settings accessible
- [ ] Login as Staff — restricted nav based on permissions, no org settings
- [ ] Org switcher appears for multi-org users, hidden for single-org
- [ ] Invite link `/invite/<token>` accepts correctly when logged in
- [ ] Invite link redirects to signup for new users, then accepts on completion
- [ ] `NoOrganizationScreen` shown for authenticated users with no membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization invite links with signup, login, acceptance, expiration, and error handling.
  * Added organization management tabs for roles, members, and pending invitations.
  * Added role creation, permission management, member role changes, removals, and invite resend/revoke actions.
  * Navigation and dashboard access now reflect organization-specific permissions.
* **Improvements**
  * Invite pages use a streamlined full-screen layout without the standard header or sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->